### PR TITLE
fix: replace all unicode escape sequences with actual emoji

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -13,19 +13,19 @@ export default function AboutPage() {
       title: t.about.related.home.title,
       href: "/",
       description: t.about.related.home.description,
-      icon: "\uD83C\uDFE0",
+      icon: "🏠",
     },
     {
       title: t.about.related.architecture.title,
       href: "/architecture",
       description: t.about.related.architecture.description,
-      icon: "\uD83C\uDFD7\uFE0F",
+      icon: "🏗️",
     },
     {
       title: t.about.related.tools.title,
       href: "/tools",
       description: t.about.related.tools.description,
-      icon: "\uD83D\uDD27",
+      icon: "🔧",
     },
   ];
 

--- a/src/app/commands/page.tsx
+++ b/src/app/commands/page.tsx
@@ -10,43 +10,43 @@ export default function CommandsPage() {
       title: "入口与启动",
       href: "/entry",
       description: "启动流程详解",
-      icon: "\uD83D\uDE80",
+      icon: "🚀",
     },
     {
       title: "工具系统",
       href: "/tools",
       description: "40+ 工具实现",
-      icon: "\uD83D\uDD27",
+      icon: "🔧",
     },
     {
       title: "UI框架",
       href: "/ink",
       description: "终端 UI 渲染",
-      icon: "\uD83C\uDFA8",
+      icon: "🎨",
     },
     {
       title: "查询引擎",
       href: "/query-engine",
       description: "Prompt 构建与查询",
-      icon: "\uD83D\uDD0D",
+      icon: "🔍",
     },
     {
       title: "上下文系统",
       href: "/context",
       description: "上下文管理",
-      icon: "\uD83D\uDCCB",
+      icon: "📋",
     },
     {
       title: "记忆系统",
       href: "/memory",
       description: "会话记忆",
-      icon: "\uD83E\uDDE0",
+      icon: "🧠",
     },
     {
       title: "权限系统",
       href: "/permissions",
       description: "工具权限控制",
-      icon: "\uD83D\uDD12",
+      icon: "🔒",
     },
   ];
 
@@ -135,7 +135,7 @@ export default function CommandsPage() {
     <ModuleLayout
       title="命令系统"
       subtitle="Claude Code CLI 40+ 命令的架构设计、分类体系与执行流程深度解析"
-      icon="\u2328\uFE0F"
+      icon="⌨️"
       category="核心架构"
       relatedModules={relatedModules}
     >

--- a/src/app/plugins/page.tsx
+++ b/src/app/plugins/page.tsx
@@ -10,31 +10,31 @@ export default function PluginsPage() {
       title: "工具系统",
       href: "/tools",
       description: "40+ 工具实现",
-      icon: "\uD83D\uDD27",
+      icon: "🔧",
     },
     {
       title: "权限系统",
       href: "/permissions",
       description: "权限控制",
-      icon: "\uD83D\uDD12",
+      icon: "🔒",
     },
     {
       title: "状态系统",
       href: "/state",
       description: "全局状态",
-      icon: "\uD83D\uDCE6",
+      icon: "📦",
     },
     {
       title: "命令系统",
       href: "/commands",
       description: "命令执行",
-      icon: "\u2328\uFE0F",
+      icon: "⌨️",
     },
     {
       title: "系统架构",
       href: "/architecture",
       description: "整体架构",
-      icon: "\uD83C\uDFD7\uFE0F",
+      icon: "🏗️",
     },
   ];
 
@@ -42,7 +42,7 @@ export default function PluginsPage() {
     <ModuleLayout
       title="插件与扩展"
       subtitle="Claude Code 的三大扩展机制 —— Plugins、Skills、MCP，打造无限可能的 AI 编程生态"
-      icon="\uD83D\uDD0C"
+      icon="🔌"
       category="核心架构"
       relatedModules={relatedModules}
     >


### PR DESCRIPTION
Fixes #41

## Problem
Unicode escape sequences (e.g. `\uD83D\uDD27`) were rendered as literal text instead of emoji characters across multiple pages.

## Changes

| File | Before | After |
|------|--------|-------|
| `about/page.tsx` | `\uD83C\uDFE0` `\uD83C\uDFD7\uFE0F` `\uD83D\uDD27` | 🏠 🏗️ 🔧 |
| `plugins/page.tsx` | `\uD83D\uDD27` `\uD83D\uDD12` `\uD83D\uDCE6` `\u2328\uFE0F` `\uD83C\uDFD7\uFE0F` `\uD83D\uDD0C` | 🔧 🔒 📦 ⌨️ 🏗️ 🔌 |
| `commands/page.tsx` | `\uD83D\uDE80` `\uD83D\uDD27` `\uD83C\uDFA8` `\uD83D\uDD0D` `\uD83D\uDCCB` `\uD83E\uDDE0` `\uD83D\uDD12` `\u2328\uFE0F` | 🚀 🔧 🎨 🔍 📋 🧠 🔒 ⌨️ |

Note: `\u00A0` (non-breaking space) in `CodeFlow.tsx` and `ink/page.tsx` was left unchanged as it is a valid whitespace character.